### PR TITLE
rm duplicate link from readme.md

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,6 @@
 
 <p>To get PP-M working, you need to download python 2.7 from <a href="https://www.python.org/downloads/">https://www.python.org/downloads/</a> . Then, just open Core.py in your python client and you're good to go.</p>
 
-<h2>
-<a id="other-versions" class="anchor" href="#other-versions" aria-hidden="true"><span class="octicon octicon-link"></span></a>Other versions</h2>
-
-<p>To get the single version of this project, go to <a href="http://bluenexus.github.io/PyPass-Uni/">http://bluenexus.github.io/PyPass-Uni/</a> </p>
-
       <footer class="site-footer">
         <span class="site-footer-owner"><a href="https://github.com/BlueNexus/PyPass-Multi">Pypass-multi</a> is maintained by <a href="https://github.com/BlueNexus">BlueNexus</a>.</span>
 


### PR DESCRIPTION
Duplicate link in index.html as a side effect from copying readme.md removed.
